### PR TITLE
Make xmpppy run with gevent

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if sys.version < '2.2.3':
 
 # Set proper release version in source code also!!!
 setup(name='xmpppy',
-      version='0.5.1a1',
+      version='0.5.1a2',
       author='Alexey Nezhdanov',
       author_email='snakeru@users.sourceforge.net',
       url='http://xmpppy.sourceforge.net/',

--- a/xmpp/transports.py
+++ b/xmpp/transports.py
@@ -357,8 +357,6 @@ class TLS(PlugIn):
         """ Here we should switch pending_data to hint mode."""
         tcpsock=self._owner.Connection
         tcpsock._sslObj    = socket.ssl(tcpsock._sock, None, None)
-        tcpsock._sslIssuer = tcpsock._sslObj.issuer()
-        tcpsock._sslServer = tcpsock._sslObj.server()
         tcpsock._recv = tcpsock._sslObj.read
         tcpsock._send = tcpsock._sslObj.write
 


### PR DESCRIPTION
Hi,

those 2 calls prevent running with gevent enabled.

"gevent enabled" ==  from gevent import monkey; monkey.patch_all()

Those removed variables are not used in the project anywhere. Perhaps they are used by some dependent variables. Maybe it would be better to conditionally disable those, in case we are running with gevent. 
