### PR TITLE
transport.py: remove obsolete issuer()/server()

### DIFF
--- a/xmpp/transports.py
+++ b/xmpp/transports.py
@@ -357,8 +357,6 @@ class TLS(PlugIn):
         """ Here we should switch pending_data to hint mode."""
         tcpsock=self._owner.Connection
         tcpsock._sslObj    = socket.ssl(tcpsock._sock, None, None)
-        tcpsock._sslIssuer = tcpsock._sslObj.issuer()
-        tcpsock._sslServer = tcpsock._sslObj.server()
         tcpsock._recv = tcpsock._sslObj.read
         tcpsock._send = tcpsock._sslObj.write
 


### PR DESCRIPTION
_sslServer and _sslIssuer weren't used anywhere in the project.
The methods issuer() and server() is not available in python2.7.9: https://hg.python.org/cpython/file/51de0da524b4/Lib/ssl.py